### PR TITLE
feature/add Kitty to the first empty space; disable Add Kitty button; style buttons

### DIFF
--- a/components/corral/Corral.jsx
+++ b/components/corral/Corral.jsx
@@ -56,7 +56,7 @@ const Corral = ({ corralCount }) => {
         <div>{corralSpaces.map((space) => space)}</div>
         <button
           onClick={onAddKittyClick}
-          disabled={corralSpaces.every((space) => space)}
+          disabled={corralSpaces.every((space) => space.props.children)}
         >
           Add Kitty
         </button>

--- a/components/corral/Corral.jsx
+++ b/components/corral/Corral.jsx
@@ -44,7 +44,7 @@ const Corral = ({ corralCount }) => {
 
   const onEmptyCorralClick = () => {
     setCorralSpaces((prevState) =>
-      prevState.map((item, i) => <CorralSpace key={i} />)
+      prevState.map((space, i) => <CorralSpace key={i} />)
     );
   };
 
@@ -53,14 +53,14 @@ const Corral = ({ corralCount }) => {
   return (
     <div className={styles.Corral}>
       <section>
-        <div>{corralSpaces.map((item) => item)}</div>
+        <div>{corralSpaces.map((space) => space)}</div>
         <button
           onClick={onAddKittyClick}
-          // disabled={corralSpaces.every((item) => item)}
+          disabled={corralSpaces.every((space) => space)}
         >
           Add Kitty
         </button>
-        {corralSpaces.every((item) => item.props?.children) && (
+        {corralSpaces.every((space) => space.props?.children) && (
           <>
             <p>The Kitty Corral is full.</p>
             <button onClick={onEmptyCorralClick}>Empty Corral</button>

--- a/components/corral/Corral.jsx
+++ b/components/corral/Corral.jsx
@@ -18,20 +18,25 @@ const Corral = ({ corralCount }) => {
   const onAddKittyClick = () => {
     console.log('add one kitty');
     setCorralSpaces((prevState) => {
+      let length = 0;
+
+      prevState.find((corralSpace, i) => {
+        if (!corralSpace.props.children) {
+          console.log('HELLO: ', i);
+          length = i;
+          return corralSpace;
+        }
+        console.log('LENGTH for each: ', length);
+      });
+
       return prevState.map((corralSpace, i) => {
-        if (
-          !prevState[i - 1] ||
-          (prevState[i - 1].props.children &&
-            !prevState[i + 1]?.props.children) ||
-          (prevState[i - 1].props.children && !prevState[i + 1])
-        ) {
-          console.log('A');
+        console.log('LENGTH map: ', length);
+        if (i === length)
           return (
             <CorralSpace key={i}>
               <Kitty i={i} setCorralSpaces={setCorralSpaces} />
             </CorralSpace>
           );
-        }
         return corralSpace;
       });
     });

--- a/components/corral/Corral.module.css
+++ b/components/corral/Corral.module.css
@@ -27,10 +27,16 @@
   /* border: 3px dotted yellow; */
 }
 
+.Corral button {
+  border-radius: 5px;
+  padding: .25rem .5rem;
+}
+
 .Corral a {
   border: 1px solid blue;
   background-color: blue;
-  padding: .25rem;
+  border-radius: 5px;
+  padding: .25rem .5rem;
   color: yellow;
   transition: 500ms;
 }


### PR DESCRIPTION
The click handler now adds a Kitty to the first empty CorralSpace in the list. Whereas before, it only added a Kitty to the last empty CorralSpace. Therefore, if a Kitty is removed before the end of the list, and there are occupied CorralSpaces after this new empty CorralSpace, the next button click will fill in this new empty CorralSpace that is earlier in the list instead of filling in the last empty CorralSpace in the list. Hooray!!!

The Add Kitty button has also been updated to be disabled when all the CorralSpace are full.

Added some button styling too.