### PR TITLE
fix/remove first kitty

### DIFF
--- a/components/corral/Corral.jsx
+++ b/components/corral/Corral.jsx
@@ -30,7 +30,7 @@ const Corral = ({ corralCount }) => {
         if (i === length)
           return (
             <CorralSpace key={i}>
-              <Kitty i={i} setCorralSpaces={setCorralSpaces} />
+              <Kitty position={i} setCorralSpaces={setCorralSpaces} />
             </CorralSpace>
           );
         return corralSpace;

--- a/components/kitty/Kitty.jsx
+++ b/components/kitty/Kitty.jsx
@@ -2,11 +2,11 @@ import Image from 'next/image';
 import CorralSpace from '../CorralSpace/CorralSpace';
 import styles from './Kitty.module.css';
 
-const Kitty = ({ i, setCorralSpaces }) => {
+const Kitty = ({ position, setCorralSpaces }) => {
   const onRemoveKittyClick = () => {
     setCorralSpaces((prevState) =>
       prevState.map((space, index) => {
-        if (i === index) space = <CorralSpace key={i} />;
+        if (index === position) space = <CorralSpace key={index} />;
         return space;
       })
     );

--- a/components/kitty/Kitty.jsx
+++ b/components/kitty/Kitty.jsx
@@ -3,18 +3,17 @@ import CorralSpace from '../CorralSpace/CorralSpace';
 import styles from './Kitty.module.css';
 
 const Kitty = ({ i, setCorralSpaces }) => {
-  const onVisibleClick = () => {
-    console.log('I: ', i);
+  const onRemoveKittyClick = () => {
     setCorralSpaces((prevState) =>
-      prevState.map((space) => {
-        prevState[i] = <CorralSpace key={i} />;
+      prevState.map((space, index) => {
+        if (i === index) space = <CorralSpace key={i} />;
         return space;
       })
     );
   };
 
   return (
-    <div className={styles.Kitty} onClick={onVisibleClick}>
+    <div className={styles.Kitty} onClick={onRemoveKittyClick}>
       <Image
         src="https://placekitten.com/100/100"
         alt="kitten"


### PR DESCRIPTION
Clicking on a kitty removes the individual kitty, but this wasn't working for the first kitty. This has been fixed. The previous implementation mapped through the list and replaced the item in the previous state and then returned this updated previous state. Now the item is more directly replaced based on the item being mapped.